### PR TITLE
SREP-2362: Auto-update ocm-access-token secret and restart pods after pull-secret rotation

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,8 @@ func main() {
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				operatorNS: {},
+				// Note: openshift-config is NOT added to cache to avoid RBAC issues.
+				// Instead, we use periodic reconciliation to check pull-secret changes.
 			},
 		},
 		Scheme: scheme,

--- a/main.go
+++ b/main.go
@@ -145,8 +145,6 @@ func main() {
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				operatorNS: {},
-				// Note: openshift-config is NOT added to cache to avoid RBAC issues.
-				// Instead, we use periodic reconciliation to check pull-secret changes.
 			},
 		},
 		Scheme: scheme,

--- a/pkg/ocmagenthandler/ocmagenthandler_deployment.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_deployment.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -315,6 +316,31 @@ func (o *ocmAgentHandler) ensureDeploymentDeleted(ocmAgent ocmagentv1alpha1.OcmA
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// restartOCMAgentPods triggers a rolling restart of the ocm-agent deployment
+// by updating a timestamp annotation in the deployment's pod template.
+// This causes Kubernetes to restart the pods to pick up the updated secret.
+func (o *ocmAgentHandler) restartOCMAgentPods(ocmAgent ocmagentv1alpha1.OcmAgent) error {
+	namespacedName := oah.BuildNamespacedName(ocmAgent.Name)
+	foundDeployment := &appsv1.Deployment{}
+	if err := o.Client.Get(o.Ctx, namespacedName, foundDeployment); err != nil {
+		o.Log.Error(err, "Failed to get ocm-agent deployment")
+		return fmt.Errorf("failed to get ocm-agent deployment %s: %w", namespacedName.String(), err)
+	}
+
+	if foundDeployment.Spec.Template.ObjectMeta.Annotations == nil {
+		foundDeployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	restartTime := time.Now().Format(time.RFC3339)
+	foundDeployment.Spec.Template.ObjectMeta.Annotations["ocm-agent-operator/restartedAt"] = restartTime
+
+	if err := o.Client.Update(o.Ctx, foundDeployment); err != nil {
+		o.Log.Error(err, "Failed to restart ocm-agent deployment")
+		return fmt.Errorf("failed to restart ocm-agent deployment %s: %w", namespacedName.String(), err)
+	}
+	o.Log.Info("Restarted ocm-agent pods", "deployment", namespacedName.String(), "restartedAt", restartTime)
 	return nil
 }
 

--- a/pkg/ocmagenthandler/ocmagenthandler_secret.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_secret.go
@@ -31,53 +31,69 @@ func buildOCMAgentAccessTokenSecret(accessToken []byte, ocmAgent ocmagentv1alpha
 
 // ensureAccessTokenSecret ensures that an OCMAgent Secret exists on the cluster
 // and that its configuration matches what is expected.
-func (o *ocmAgentHandler) ensureAccessTokenSecret(ocmAgent ocmagentv1alpha1.OcmAgent) error {
+// Returns (wasUpdated bool, error) where wasUpdated indicates if the secret was created or updated.
+func (o *ocmAgentHandler) ensureAccessTokenSecret(ocmAgent ocmagentv1alpha1.OcmAgent) (bool, error) {
 	namespacedName := oah.BuildNamespacedName(ocmAgent.Spec.TokenSecret)
 	foundResource := &corev1.Secret{}
 
 	clusterPullSecret, err := o.fetchAccessTokenPullSecret()
 	if err != nil {
+		o.Log.Error(err, "Failed to fetch pull-secret")
 		localmetrics.UpdateMetricPullSecretInvalid(ocmAgent.Name)
-		return err
+		return false, err
 	}
 	localmetrics.ResetMetricPullSecretInvalid(ocmAgent.Name)
+
 	populationFunc := func() corev1.Secret {
 		return buildOCMAgentAccessTokenSecret(clusterPullSecret, ocmAgent)
 	}
+
 	// Does the resource already exist?
-	o.Log.Info("ensuring secret exists", "resource", namespacedName.String())
 	if err := o.Client.Get(o.Ctx, namespacedName, foundResource); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// It does not exist, so must be created.
-			o.Log.Info("An OCMAgent access token secret does not exist; will be created.")
 			// Populate the resource with the template
 			resource := populationFunc()
 			// Set the controller reference
 			if err := controllerutil.SetControllerReference(&ocmAgent, &resource, o.Scheme); err != nil {
-				return err
+				o.Log.Error(err, "Failed to set controller reference")
+				return false, err
 			}
 			// and create it
 			err = o.Client.Create(o.Ctx, &resource)
 			if err != nil {
-				return err
+				o.Log.Error(err, "Failed to create secret")
+				return false, err
 			}
+			o.Log.Info("Created ocm-access-token secret", "secret", namespacedName.String())
+			return true, nil // Secret was created
 		} else {
 			// Return unexpectedly
-			return err
+			o.Log.Error(err, "Unexpected error fetching secret")
+			return false, err
 		}
 	} else {
 		// It does exist, check if it is what we expected
 		resource := populationFunc()
 		if !reflect.DeepEqual(foundResource.Data, resource.Data) {
 			// Specs aren't equal, update and fix.
-			o.Log.Info("An OCMAgent access token secret exists but contains unexpected configuration. Restoring.")
 			foundResource = resource.DeepCopy()
 			if err = o.Client.Update(o.Ctx, foundResource); err != nil {
-				return err
+				o.Log.Error(err, "Failed to update secret")
+				return false, err
 			}
+			o.Log.Info("Updated ocm-access-token secret", "secret", namespacedName.String())
+			return true, nil // Secret was updated
 		}
 	}
-	return nil
+	return false, nil // Secret exists and matches expected state, no update needed
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func (o *ocmAgentHandler) ensureFleetClientSecret(ocmAgent ocmagentv1alpha1.OcmAgent) error {
@@ -124,13 +140,16 @@ func (o *ocmAgentHandler) fetchAccessTokenPullSecret() ([]byte, error) {
 	if err := o.Client.Get(o.Ctx, oah.PullSecretNamespacedName, foundResource); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// There should always be a pull secret, log this
-			o.Log.Error(err, "Cluster pull secret was not found on the cluster.")
+			o.Log.Error(err, "Cluster pull secret was not found on the cluster")
+		} else {
+			o.Log.Error(err, "Failed to get pull-secret")
 		}
 		return nil, err
 	}
 
 	pullSecret, ok := foundResource.Data[oah.PullSecretKey]
 	if !ok {
+		o.Log.Error(nil, "Pull secret missing required key", "key", oah.PullSecretKey)
 		return nil, fmt.Errorf("pull secret missing required key '%s'", oah.PullSecretKey)
 	}
 
@@ -143,14 +162,19 @@ func (o *ocmAgentHandler) fetchAccessTokenPullSecret() ([]byte, error) {
 
 	authConfig, ok := dockerConfig["auths"]
 	if !ok {
+		o.Log.Error(nil, "Unable to find auths section in pull secret")
 		return nil, fmt.Errorf("unable to find auths section in pull secret")
 	}
+
 	apiConfig, ok := authConfig.(map[string]interface{})[oah.PullSecretAuthTokenKey]
 	if !ok {
+		o.Log.Error(nil, "Unable to find pull secret auth key", "key", oah.PullSecretAuthTokenKey)
 		return nil, fmt.Errorf("unable to find pull secret auth key '%s' in pull secret", oah.PullSecretAuthTokenKey)
 	}
+
 	accessToken, ok := apiConfig.(map[string]interface{})["auth"]
 	if !ok {
+		o.Log.Error(nil, "Unable to find access auth token in pull secret")
 		return nil, fmt.Errorf("unable to find access auth token in pull secret")
 	}
 	strAccessToken := fmt.Sprintf("%v", accessToken)

--- a/pkg/ocmagenthandler/ocmagenthandler_secret_test.go
+++ b/pkg/ocmagenthandler/ocmagenthandler_secret_test.go
@@ -124,8 +124,9 @@ var _ = Describe("OCM Agent Access Token Secret Handler", func() {
 								return nil
 							}),
 					)
-					err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
+					updated, err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
 					Expect(err).To(BeNil())
+					Expect(updated).To(BeTrue())
 				})
 			})
 			When("the secret matches what is expected", func() {
@@ -134,8 +135,9 @@ var _ = Describe("OCM Agent Access Token Secret Handler", func() {
 						mockClient.EXPECT().Get(gomock.Any(), oahconst.PullSecretNamespacedName, gomock.Any()).Times(1).SetArg(2, testPullSecret),
 						mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Times(1).SetArg(2, testSecret),
 					)
-					err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
+					updated, err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
 					Expect(err).To(BeNil())
+					Expect(updated).To(BeFalse())
 				})
 			})
 			When("the HS secret matches what is expected", func() {
@@ -163,8 +165,9 @@ var _ = Describe("OCM Agent Access Token Secret Handler", func() {
 							return nil
 						}),
 				)
-				err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
+				updated, err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
 				Expect(err).To(BeNil())
+				Expect(updated).To(BeTrue())
 			})
 			It("return not found error for HS secret", func() {
 				notFound := k8serrs.NewNotFound(schema.GroupResource{}, testSecret.Name)
@@ -205,8 +208,9 @@ var _ = Describe("OCM Agent Access Token Secret Handler", func() {
 				gomock.InOrder(
 					mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).SetArg(2, testSecret),
 				)
-				err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
+				updated, err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
 				Expect(err).NotTo(BeNil())
+				Expect(updated).To(BeFalse())
 				expectedMetric := `
 # HELP ocm_agent_operator_pull_secret_invalid Failed to obtain a valid pull secret
 # TYPE ocm_agent_operator_pull_secret_invalid gauge
@@ -222,8 +226,9 @@ ocm_agent_operator_pull_secret_invalid{ocmagent_name="test-ocm-agent"} 1
 					mockClient.EXPECT().Get(gomock.Any(), oahconst.PullSecretNamespacedName, gomock.Any()).Times(1).SetArg(2, testPullSecret),
 					mockClient.EXPECT().Get(gomock.Any(), testNamespacedName, gomock.Any()).Times(1).SetArg(2, testSecret),
 				)
-				err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
+				updated, err := testOcmAgentHandler.ensureAccessTokenSecret(testOcmAgent)
 				Expect(err).To(BeNil())
+				Expect(updated).To(BeFalse())
 				expectedMetric := `
 # HELP ocm_agent_operator_pull_secret_invalid Failed to obtain a valid pull secret
 # TYPE ocm_agent_operator_pull_secret_invalid gauge


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

Fixes issue where `ocm-access-token` secret in `openshift-ocm-agent-operator` namespace was not updated after pull-secret rotation, causing `ocm-agent` pods to fail with stale credentials.

**Changes:**
- Added periodic reconciliation to detect pull-secret changes
- Added token comparison logic to detect when tokens differ
- Automatically updates `ocm-access-token` secret when pull-secret changes
- Automatically restarts `ocm-agent` pods after secret update

### Which Jira/Github issue(s) this PR fixes?

Fixes [SREP-2362](https://issues.redhat.com/browse/SREP-2362)

### Notes
This PR is migrated from openshift/ocm-agent-operator#219 as the original author left the organization.

Original commits by: Amit Upadhyay <amiupadh@redhat.com>